### PR TITLE
Should return 404 if operation not exists

### DIFF
--- a/simter-operation-rest-webflux/src/main/kotlin/tech/simter/operation/rest/webflux/handler/GetByIdHandler.kt
+++ b/simter-operation-rest-webflux/src/main/kotlin/tech/simter/operation/rest/webflux/handler/GetByIdHandler.kt
@@ -1,4 +1,3 @@
-
 package tech.simter.operation.rest.webflux.handler
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -6,7 +5,7 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.*
 import org.springframework.web.reactive.function.server.RequestPredicates.GET
-import org.springframework.web.reactive.function.server.ServerResponse.noContent
+import org.springframework.web.reactive.function.server.ServerResponse.notFound
 import org.springframework.web.reactive.function.server.ServerResponse.ok
 import reactor.core.publisher.Mono
 import tech.simter.operation.core.Operation
@@ -20,13 +19,13 @@ import tech.simter.operation.core.OperationService
 @Component
 class GetByIdHandler @Autowired constructor(
   private val operationService: OperationService
-): HandlerFunction<ServerResponse> {
+) : HandlerFunction<ServerResponse> {
   override fun handle(request: ServerRequest): Mono<ServerResponse> {
-    val mono = operationService.get( request.pathVariable("id"))
+    val mono = operationService.get(request.pathVariable("id"))
     return mono.hasElement()
       .flatMap {
         if (it) ok().contentType(APPLICATION_JSON).body(mono)
-        else noContent().build()
+        else notFound().build()
       }
   }
 

--- a/simter-operation-rest-webflux/src/test/kotlin/tech/simter/operation/rest/webflux/handler/GetByIdHandlerTest.kt
+++ b/simter-operation-rest-webflux/src/test/kotlin/tech/simter/operation/rest/webflux/handler/GetByIdHandlerTest.kt
@@ -49,7 +49,7 @@ class GetByIdHandlerTest @Autowired constructor(
     response.expectStatus().isOk
       .expectBody()
       .json(responseBody)
-    verify(exactly = 1) {service.get(id)  }
+    verify(exactly = 1) { service.get(id) }
   }
 
   @Test
@@ -61,7 +61,7 @@ class GetByIdHandlerTest @Autowired constructor(
     // invoke and verify
     client.get().uri("/$id")
       .exchange()
-      .expectStatus().isNoContent
+      .expectStatus().isNotFound
       .expectBody().isEmpty
   }
 }


### PR DESCRIPTION
Fixed error on [ Get /{id} return 204 if operation not exists ]( https://github.com/simter/simter-operation/pull/26 ) , please check whether there is any problem
Resolved https://github.com/simter/simter-operation/issues/27